### PR TITLE
Test navigator.clipboard defined before accessing

### DIFF
--- a/emscripten_browser_clipboard.h
+++ b/emscripten_browser_clipboard.h
@@ -51,7 +51,9 @@ EM_JS_INLINE(void, copy_js, (copy_handler callback, void *callback_data), {
 
 EM_JS_INLINE(void, copy_async_js, (char const *content_ptr), {
   /// Attempt to copy the provided text asynchronously
-  navigator.clipboard.writeText(UTF8ToString(content_ptr));
+  if (navigator.clipboard !== undefined) {
+    navigator.clipboard.writeText(UTF8ToString(content_ptr));
+  }
 });
 
 }


### PR DESCRIPTION
Most browsers now require that the the web page is "Secure" or else they do not allow access to the clipboard, this includes navigator.clipboard.  I noticed that in my application that when I access my app locally (where https is not applied yet) invoking the copy methods results in an exception where "writeText" does not exist in "undefined".

To smooth over this, I added a test for the clipboard existing before calling the method.

If you agree with this idea, I imagine we will want to output an error when this if check fails, or maybe modify the function signature to return a variable indicating success.