### PR TITLE
Update emscripten_browser_clipboard.h

### DIFF
--- a/emscripten_browser_clipboard.h
+++ b/emscripten_browser_clipboard.h
@@ -51,6 +51,30 @@ EM_JS_INLINE(void, copy_js, (copy_handler callback, void *callback_data), {
 EM_JS_INLINE(void, copy_async_js, (char const *content_ptr), {
   /// Attempt to copy the provided text asynchronously
   navigator.clipboard.writeText(UTF8ToString(content_ptr));
+  if (navigator.clipboard && window.isSecureContext) {
+    return navigator.clipboard.writeText(UTF8ToString(content_ptr))
+           .then(()  => {})
+           .catch(() => {alert("something went wrong");});
+  } else {
+  /// Fallback method using document.execCommand('copy'), 
+  /// this fallback method is not guaranteed to work in all browsers since
+  /// document.execCommand('copy') is deprecated.  
+    let textArea = document.createElement("textarea");
+    document.body.appendChild(textArea);
+        
+    textArea.value = UTF8ToString(content_ptr);
+
+    textArea.focus();
+    textArea.select();
+
+    try {
+      document.execCommand('copy');
+    } catch (error) {
+      console.error(error);
+    } finally {
+      document.body.removeChild(textArea);
+    }
+  }  
 });
 
 } // namespace detail

--- a/emscripten_browser_clipboard.h
+++ b/emscripten_browser_clipboard.h
@@ -50,7 +50,6 @@ EM_JS_INLINE(void, copy_js, (copy_handler callback, void *callback_data), {
 
 EM_JS_INLINE(void, copy_async_js, (char const *content_ptr), {
   /// Attempt to copy the provided text asynchronously
-  navigator.clipboard.writeText(UTF8ToString(content_ptr));
   if (navigator.clipboard && window.isSecureContext) {
     return navigator.clipboard.writeText(UTF8ToString(content_ptr))
            .then(()  => {})

--- a/emscripten_browser_clipboard.h
+++ b/emscripten_browser_clipboard.h
@@ -55,9 +55,9 @@ EM_JS_INLINE(void, copy_async_js, (char const *content_ptr), {
            .then(()  => {})
            .catch(() => {alert("something went wrong");});
   } else {
-  /// Fallback method using document.execCommand('copy'), 
-  /// this fallback method is not guaranteed to work in all browsers since
-  /// document.execCommand('copy') is deprecated.  
+    // Fallback method using document.execCommand('copy'), 
+    // this fallback method is not guaranteed to work in all browsers since
+    // document.execCommand('copy') is deprecated.  
     let textArea = document.createElement("textarea");
     document.body.appendChild(textArea);
         


### PR DESCRIPTION
Add check for the clipboard as well as for the context to be secured (https or localhost) otherwise try to use a fallback method with old  'copy'.